### PR TITLE
Upgrade Newtonsoft.Json dependency

### DIFF
--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -40,6 +40,7 @@
     <Compile Include="KachingPlugIn\Initialization\Initialization.cs" />
     <Compile Include="KachingPlugIn\Models\Folder.cs" />
     <Compile Include="KachingPlugIn\Models\Configuration.cs" />
+    <Compile Include="KachingPlugIn\Models\MarketPriceConverter.cs" />
     <Compile Include="KachingPlugIn\Models\Product.cs" />
     <Compile Include="KachingPlugIn\Models\Tag.cs" />
     <Compile Include="KachingPlugIn\Models\L10nString.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -198,8 +198,8 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/KachingPlugIn.nuspec
+++ b/KachingPlugIn.nuspec
@@ -15,6 +15,7 @@
       <dependency id="EPiServer.CMS.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.CMS.UI.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.Commerce.Core" version="[13.0.0,14.0.0)" />
+      <dependency id="Newtonsoft.Json" version="11.0.1" />
     </dependencies>
   </metadata>
   <files>

--- a/KachingPlugIn/Models/MarketPrice.cs
+++ b/KachingPlugIn/Models/MarketPrice.cs
@@ -1,51 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace KachingPlugIn.Models
 {
-    public class MarketPriceConverter : JsonConverter
-    {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            MarketPrice l10n = (MarketPrice)value;
-            if (l10n.MarketSpecific != null)
-            {
-                serializer.Serialize(writer, l10n.MarketSpecific);
-            }
-            else
-            {
-                writer.WriteValue(l10n.Single);
-            }
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            // Only handling serialization for now
-            throw new NotImplementedException();
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(MarketPrice);
-        }
-    }
-
-
     [JsonConverter(typeof(MarketPriceConverter))]
     public class MarketPrice
     {
-        public decimal Single { get; set; }
-        public Dictionary<string, decimal> MarketSpecific { get; set; }
+        public decimal Single { get; }
+        public Dictionary<string, decimal> MarketSpecific { get; }
 
-        public MarketPrice(decimal Value)
+        public MarketPrice(decimal value)
         {
-            this.Single = Value;
+            Single = value;
         }
 
-        public MarketPrice(Dictionary<string, decimal> Value)
+        public MarketPrice(Dictionary<string, decimal> value)
         {
-            this.MarketSpecific = Value;
+            MarketSpecific = value;
         }
     }
 }

--- a/KachingPlugIn/Models/MarketPriceConverter.cs
+++ b/KachingPlugIn/Models/MarketPriceConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace KachingPlugIn.Models
+{
+    public class MarketPriceConverter : JsonConverter<MarketPrice>
+    {
+        public override void WriteJson(
+            JsonWriter writer,
+            MarketPrice value,
+            JsonSerializer serializer)
+        {
+            if (value.MarketSpecific != null)
+            {
+                serializer.Serialize(writer, value.MarketSpecific);
+            }
+            else
+            {
+                writer.WriteValue(value.Single);
+            }
+        }
+
+        public override MarketPrice ReadJson(
+            JsonReader reader,
+            Type objectType,
+            MarketPrice existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/app.config
+++ b/app.config
@@ -155,7 +155,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral" />

--- a/packages.config
+++ b/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net461" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net461" />


### PR DESCRIPTION
This is a small change that uses Newtonsoft.Json, version 11.0.1 instead of 9.0.0.
Besides, it also uses the generic version of JsonConverter in the MarketPriceConverter.