### PR TITLE
Support single variants exported as product

### DIFF
--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -38,6 +38,8 @@
     <Compile Include="KachingPlugIn\Helpers\APIFacade.cs" />
     <Compile Include="KachingPlugIn\Helpers\StringExtensions.cs" />
     <Compile Include="KachingPlugIn\Initialization\Initialization.cs" />
+    <Compile Include="KachingPlugIn\Models\Dimension.cs" />
+    <Compile Include="KachingPlugIn\Models\DimensionValue.cs" />
     <Compile Include="KachingPlugIn\Models\Folder.cs" />
     <Compile Include="KachingPlugIn\Models\Configuration.cs" />
     <Compile Include="KachingPlugIn\Models\Product.cs" />
@@ -45,6 +47,7 @@
     <Compile Include="KachingPlugIn\Models\L10nString.cs" />
     <Compile Include="KachingPlugIn\Models\MarketPrice.cs" />
     <Compile Include="KachingPlugIn\Models\ProductMetadata.cs" />
+    <Compile Include="KachingPlugIn\Models\Variant.cs" />
     <Compile Include="KachingPlugIn\Services\CategoryExportService.cs" />
     <Compile Include="KachingPlugIn\Services\CategoryExportSingleton.cs" />
     <Compile Include="KachingPlugIn\Services\IExportState.cs" />

--- a/KachingPlugIn/Controllers/KachingPlugInController.cs
+++ b/KachingPlugIn/Controllers/KachingPlugInController.cs
@@ -1,10 +1,14 @@
-﻿using EPiServer.Logging;
+﻿using System;
+using EPiServer.Logging;
 using EPiServer.PlugIn;
 using KachingPlugIn.Helpers;
 using KachingPlugIn.Models;
 using KachingPlugIn.Services;
 using KachingPlugIn.ViewModels;
 using System.Web.Mvc;
+using EPiServer.Security;
+using EPiServer.Shell;
+using PlugInArea = EPiServer.PlugIn.PlugInArea;
 
 namespace KachingPlugIn.Controllers
 {
@@ -33,12 +37,13 @@ namespace KachingPlugIn.Controllers
 
             var viewModel = new PlugInViewModel();
             viewModel.ProgressViewModel = BuildProgressViewModel();
-            viewModel.ProgressViewLocation = ViewLocation("Progress");
+            viewModel.ExportSingleVariantAsProduct = configuration.ExportSingleVariantAsProduct;
             viewModel.ProductsImportUrl = configuration.ProductsImportUrl;
             viewModel.TagsImportUrl = configuration.TagsImportUrl;
             viewModel.FoldersImportUrl = configuration.FoldersImportUrl;
             viewModel.ProductExportStartButtonDisabled = !configuration.ProductsImportUrl.IsValidProductsImportUrl();
-            viewModel.CategoryExportStartButtonDisabled = !configuration.TagsImportUrl.IsValidTagsImportUrl() || !configuration.FoldersImportUrl.IsValidFoldersImportUrl();
+            viewModel.CategoryExportStartButtonDisabled = !configuration.TagsImportUrl.IsValidTagsImportUrl() ||
+                                                          !configuration.FoldersImportUrl.IsValidFoldersImportUrl();
 
             return View("Index", viewModel);
         }
@@ -61,32 +66,15 @@ namespace KachingPlugIn.Controllers
         }
 
         [HttpPost]
-        public ActionResult UpdateProductImportUrl(string productsImportUrl)
+        public ActionResult UpdateConfiguration(PlugInViewModel viewModel)
         {
-            _log.Information("UpdateProductImportUrl: " + productsImportUrl);
             var configuration = Configuration.Instance();
-            configuration.ProductsImportUrl = productsImportUrl;
+            configuration.ExportSingleVariantAsProduct = viewModel.ExportSingleVariantAsProduct;
+            configuration.FoldersImportUrl = viewModel.FoldersImportUrl;
+            configuration.ProductsImportUrl = viewModel.ProductsImportUrl;
+            configuration.TagsImportUrl = viewModel.TagsImportUrl;
             configuration.Save();
-            return RedirectToAction("Index", "KachingPlugIn");
-        }
 
-        [HttpPost]
-        public ActionResult UpdateTagsImportUrl(string tagsImportUrl)
-        {
-            _log.Information("UpdateTagsImportUrl: " + tagsImportUrl);
-            var configuration = Configuration.Instance();
-            configuration.TagsImportUrl = tagsImportUrl;
-            configuration.Save();
-            return RedirectToAction("Index", "KachingPlugIn");
-        }
-
-        [HttpPost]
-        public ActionResult UpdateFoldersImportUrl(string foldersImportUrl)
-        {
-            _log.Information("UpdateFoldersImportUrl: " + foldersImportUrl);
-            var configuration = Configuration.Instance();
-            configuration.FoldersImportUrl = foldersImportUrl;
-            configuration.Save();
             return RedirectToAction("Index", "KachingPlugIn");
         }
 
@@ -102,7 +90,9 @@ namespace KachingPlugIn.Controllers
                 _categoryExport.Polls += 1;
             }
 
-            return PartialView(ViewLocation("Progress"), BuildProgressViewModel());
+            return PartialView(
+                Paths.ToResource("KachingPlugIn", "KachingPlugIn/Views/Progress.cshtml"),
+                BuildProgressViewModel());
         }
 
         protected override void OnAuthorization(AuthorizationContext filterContext)
@@ -147,11 +137,6 @@ namespace KachingPlugIn.Controllers
             }
             
             return result;
-        }
-
-        private string ViewLocation(string viewName)
-        {
-            return $"{EPiServer.Shell.Paths.ProtectedRootPath}KachingPlugIn/Views/{viewName}.cshtml";
         }
     }
 }

--- a/KachingPlugIn/Controllers/KachingPlugInController.cs
+++ b/KachingPlugIn/Controllers/KachingPlugInController.cs
@@ -105,6 +105,16 @@ namespace KachingPlugIn.Controllers
             return PartialView(ViewLocation("Progress"), BuildProgressViewModel());
         }
 
+        protected override void OnAuthorization(AuthorizationContext filterContext)
+        {
+            if (!PrincipalInfo.HasAdminAccess)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            base.OnAuthorization(filterContext);
+        }
+
         private ProgressViewModel BuildProgressViewModel()
         {
             var result = new ProgressViewModel();

--- a/KachingPlugIn/Controllers/KachingPlugInController.cs
+++ b/KachingPlugIn/Controllers/KachingPlugInController.cs
@@ -91,7 +91,7 @@ namespace KachingPlugIn.Controllers
             }
 
             return PartialView(
-                Paths.ToResource("KachingPlugIn", "KachingPlugIn/Views/Progress.cshtml"),
+                Paths.ToResource("KachingPlugIn", "Views/Progress.cshtml"),
                 BuildProgressViewModel());
         }
 

--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -1,9 +1,7 @@
 ﻿using EPiServer.Commerce.Catalog.ContentTypes;
-using EPiServer.Logging;
 using KachingPlugIn.Helpers;
 using KachingPlugIn.Models;
 using EPiServer.Web.Routing;
-using Mediachase.Commerce;
 using Mediachase.Commerce.Catalog;
 using Mediachase.Commerce.Markets;
 using Mediachase.Commerce.Pricing;
@@ -11,7 +9,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EPiServer;
+using EPiServer.Commerce.Catalog.Linking;
 using EPiServer.Commerce.SpecializedProperties;
+using EPiServer.Core;
+using Mediachase.Commerce;
 
 namespace KachingPlugIn.Factories
 {
@@ -21,45 +22,31 @@ namespace KachingPlugIn.Factories
         private readonly IMarketService _marketService;
         private readonly IUrlResolver _urlResolver;
         private readonly IPriceService _priceService;
+        private readonly IRelationRepository _relationRepository;
         private readonly L10nStringFactory _l10nStringFactory;
-        private readonly ILogger _log = LogManager.GetLogger(typeof(ProductFactory));
 
         public ProductFactory(
             IContentLoader contentLoader,
             IMarketService marketService,
             IUrlResolver urlResolver,
             IPriceService priceService,
+            IRelationRepository relationRepository,
             L10nStringFactory l10NStringFactory)
         {
             _contentLoader = contentLoader;
             _marketService = marketService;
             _urlResolver = urlResolver;
             _priceService = priceService;
+            _relationRepository = relationRepository;
             _l10nStringFactory = l10NStringFactory;
         }
 
-        public Product BuildKaChingProduct(ProductContent product, IList<string> tags, string skipVariantCode)
+        public Product BuildKaChingProduct(ProductContent product, ICollection<string> tags, string skipVariantCode)
         {
             var kachingProduct = new Product();
 
-            /* ---------------------------- */
-            /* Assign id */
-            /* ---------------------------- */
-
             kachingProduct.Id = product.Code;
-
-            /* ---------------------------- */
-            /* Find name for all localizations */
-            /* ---------------------------- */
-
             kachingProduct.Name = _l10nStringFactory.LocalizedProductName(product);
-
-            /* ---------------------------- */
-            /* Find prices for product */
-            /* RetailPrice in Ka-ching is including VAT style tax and excluding sales tax style tax */
-            /* ---------------------------- */
-
-            kachingProduct.RetailPrice = MarketPriceForCode(product.Code);
 
             /* ---------------------------- */
             /* Barcode is just a string, but needs to fit the barcodes on the products in the store.
@@ -110,79 +97,83 @@ namespace KachingPlugIn.Factories
                 kachingProduct.ImageUrl = absoluteUrl;
             }
 
-            var kachingVariants = new List<Variant>();
+            IEnumerable<ContentReference> variantRefs = _relationRepository
+                .GetChildren<ProductVariation>(product.ContentLink)
+                .Select(r => r.Child);
 
-            var variantLinks = product.GetVariants();
-            var variants = variantLinks.Select(x => _contentLoader.Get<VariationContent>(x));
-            foreach (var variation in variants)
+            ICollection<VariationContent> variants = _contentLoader
+                .GetItems(variantRefs, LanguageSelector.MasterLanguage())
+                .OfType<VariationContent>()
+                .ToArray();
+
+            if (variants.Count == 1 &&
+                Configuration.Instance().ExportSingleVariantAsProduct)
             {
-                if (skipVariantCode != null && skipVariantCode == variation.Code)
-                {
-                    continue;
-                }
+                // If the product has only one variant and ExportSingleVariantAsProduct is configured to true,
+                // then put all variant properties on the product instead.
+                var variant = variants.First();
 
-                var kachingVariant = new Variant();
-                kachingVariant.Id = variation.Code;
+                kachingProduct.Id = variant.Code;
+                //kachingProduct.Barcode = variant.Barcode;
+                kachingProduct.Name = _l10nStringFactory.LocalizedVariantName(variant);
+                kachingProduct.RetailPrice = MarketPriceForCode(variant.Code);
 
-                /* ---------------------------- */
-                /* Barcode is just a string, but needs to fit the barcodes on the products in the store. */
-                /* ---------------------------- */
-                // kachingVariant.Barcode = variant.Barcode;
-
-                /* ---------------------------- */
-                /* Assign localized variant name if it's different than product name */
-                /* ---------------------------- */
-
-                var variantName = _l10nStringFactory.LocalizedVariantName(variation);
-                if (!variantName.Equals(kachingProduct.Name))
-                {
-                    kachingVariant.Name = variantName;
-                }
-
-                /* ---------------------------- */
-                /* Example of dimension and dimension value assignment from the Quicksilver site. */
-                /* ---------------------------- */
-
-                //kachingVariant.DimensionValues = new Dictionary<string, string>();
-                //kachingVariant.DimensionValues[colorDimension.Id] = variant.Color.ToLower().Replace(' ', '_');
-                //kachingVariant.DimensionValues[sizeDimension.Id] = variant.Size.ToLower().Replace(' ', '_');
-
-                /* ---------------------------- */
-                /* Find prices for variant */
-                /* RetailPrice in Ka-ching is including VAT style tax and excluding sales tax style tax */
-                /* ---------------------------- */
-
-                kachingVariant.RetailPrice = MarketPriceForCode(variation.Code);
-
-                /* ---------------------------- */
-                /* Find an image */
-                /* ---------------------------- */
-
-                CommerceMedia variantImage = variation.CommerceMediaCollection.FirstOrDefault();
-                if (variantImage != null)
-                {
-                    string absoluteUrl = _urlResolver.GetUrl(
-                        variantImage.AssetLink,
-                        string.Empty,
-                        new UrlResolverArguments { ForceCanonical = true });
-                    kachingVariant.ImageUrl = absoluteUrl;
-                }
-
-                // Make sure umbrella product is assigned an image url
-                // If references are likely to change without triggering an update in Ka-ching
-                // talk to us about enabling image import where Ka-ching downloads 
-                // and stores the image to avoid dangling references.
                 if (kachingProduct.ImageUrl == null)
                 {
-                    kachingProduct.ImageUrl = kachingVariant.ImageUrl;
+                    CommerceMedia variantImage = variant.CommerceMediaCollection.FirstOrDefault();
+                    if (variantImage != null)
+                    {
+                        string absoluteUrl = _urlResolver.GetUrl(
+                            variantImage.AssetLink,
+                            string.Empty,
+                            new UrlResolverArguments { ForceCanonical = true });
+                        kachingProduct.ImageUrl = absoluteUrl;
+                    }
+                }
+            }
+            else if (variants.Count > 0)
+            {
+                var kachingVariants = new List<Variant>(variants.Count);
+
+                foreach (var variant in variants)
+                {
+                    if (skipVariantCode != null &&
+                        skipVariantCode == variant.Code)
+                    {
+                        continue;
+                    }
+
+                    var kachingVariant = new Variant();
+                    kachingVariant.Id = variant.Code;
+                    //kachingVariant.Barcode = variant.Barcode;
+
+                    var variantName = _l10nStringFactory.LocalizedVariantName(variant);
+                    if (!variantName.Equals(kachingProduct.Name))
+                    {
+                        kachingVariant.Name = variantName;
+                    }
+
+                    kachingVariant.RetailPrice = MarketPriceForCode(variant.Code);
+
+                    CommerceMedia variantImage = variant.CommerceMediaCollection.FirstOrDefault();
+                    if (variantImage != null)
+                    {
+                        string absoluteUrl = _urlResolver.GetUrl(
+                            variantImage.AssetLink,
+                            string.Empty,
+                            new UrlResolverArguments { ForceCanonical = true });
+                        kachingVariant.ImageUrl = absoluteUrl;
+                    }
+
+                    if (kachingProduct.ImageUrl == null)
+                    {
+                        kachingProduct.ImageUrl = kachingVariant.ImageUrl;
+                    }
+
+                    kachingVariants.Add(kachingVariant);
                 }
 
-                kachingVariants.Add(kachingVariant);
-            }
-
-            if (kachingVariants.Count > 0)
-            {
-                kachingProduct.Variants = kachingVariants.ToArray();
+                kachingProduct.Variants = kachingVariants;
             }
 
             /* ---------------------------- */
@@ -241,16 +232,16 @@ namespace KachingPlugIn.Factories
         private MarketPrice MarketPriceForCode(string code)
         {
             /* ---------------------------- */
-            /* Find prices for all markets */
+            /* Find prices for all markets  */
             /* ---------------------------- */
 
             var markets = _marketService.GetAllMarkets();
             var prices = new Dictionary<string, decimal>();
             foreach (var market in markets)
             {
-                var filter = new PriceFilter()
+                var filter = new PriceFilter
                 {
-                    Currencies = new Currency[] { market.DefaultCurrency }
+                    Currencies = new[] { market.DefaultCurrency }
                 };
 
                 var price = _priceService.GetPrices(
@@ -266,11 +257,9 @@ namespace KachingPlugIn.Factories
                 }
             }
 
-            if (prices.Count == 0)
-            {
-                return null;
-            }
-            return new MarketPrice(prices);
+            return prices.Count == 0
+                ? null
+                : new MarketPrice(prices);
         }
     }
 }

--- a/KachingPlugIn/Models/Configuration.cs
+++ b/KachingPlugIn/Models/Configuration.cs
@@ -11,7 +11,7 @@ namespace KachingPlugIn.Models
 
         private static DynamicDataStore Store()
         {
-            return DynamicDataStoreFactory.Instance.GetStore("Kaching.AddOn.Configuration");
+            return DynamicDataStoreFactory.Instance.GetStore(typeof(Configuration));
         } 
 
         public static Configuration Instance()

--- a/KachingPlugIn/Models/Configuration.cs
+++ b/KachingPlugIn/Models/Configuration.cs
@@ -4,13 +4,14 @@ using System;
 
 namespace KachingPlugIn.Models
 {
+    [EPiServerDataStore(AutomaticallyCreateStore = true, AutomaticallyRemapStore = true, StoreName = "Kaching.AddOn.Configuration")]
     public class Configuration : IDynamicData
     {
-        private static Identity ID = Identity.NewIdentity(new Guid("9f070fad-4c4c-49c6-9443-510ab091500a"));
+        private static readonly Identity ID = Identity.NewIdentity(new Guid("9f070fad-4c4c-49c6-9443-510ab091500a"));
 
         private static DynamicDataStore Store()
         {
-            return DynamicDataStoreFactory.Instance.CreateStore("Kaching.AddOn.Configuration", typeof(Configuration));
+            return DynamicDataStoreFactory.Instance.GetStore("Kaching.AddOn.Configuration");
         } 
 
         public static Configuration Instance()
@@ -21,6 +22,7 @@ namespace KachingPlugIn.Models
                 result = new Configuration();
                 result.Save();
             }
+
             return result;
         }
 
@@ -29,6 +31,7 @@ namespace KachingPlugIn.Models
         public string ProductsImportUrl { get; set; }
         public string TagsImportUrl { get; set; }
         public string FoldersImportUrl { get; set; }
+        public bool ExportSingleVariantAsProduct { get; set; }
 
         public Configuration()
         {
@@ -37,7 +40,7 @@ namespace KachingPlugIn.Models
 
         private void Initialize()
         {
-            Id = Configuration.ID;
+            Id = ID;
             ProductsImportUrl = string.Empty;
             TagsImportUrl = string.Empty;
             FoldersImportUrl = string.Empty;

--- a/KachingPlugIn/Models/Dimension.cs
+++ b/KachingPlugIn/Models/Dimension.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace KachingPlugIn.Models
+{
+    public class Dimension
+    {
+        public L10nString Name { get; set; }
+        public string Id { get; set; }
+        public List<DimensionValue> Values { get; set; }
+    }
+}

--- a/KachingPlugIn/Models/DimensionValue.cs
+++ b/KachingPlugIn/Models/DimensionValue.cs
@@ -1,0 +1,10 @@
+﻿namespace KachingPlugIn.Models
+{
+    public class DimensionValue
+    {
+        public string Id { get; set; }
+        public L10nString Name { get; set; }
+        public string ImageUrl { get; set; }
+        public string Color { get; set; }
+    }
+}

--- a/KachingPlugIn/Models/Variant.cs
+++ b/KachingPlugIn/Models/Variant.cs
@@ -2,21 +2,15 @@
 
 namespace KachingPlugIn.Models
 {
-    public class Product
+    public class Variant
     {
         public L10nString Name { get; set; }
-        public L10nString Description { get; set; }
         public MarketPrice RetailPrice { get; set; }
         public MarketPrice SalePrice { get; set; }
         public string Id { get; internal set; }
-        public string Barcode { get; set; }
-
         public string ImageUrl { get; set; }
 
-        public ICollection<Variant> Variants { get; set; }
-        public ICollection<Dimension> Dimensions { get; set; }
-
         public IDictionary<string, string> Attributes { get; set; }
-        public IDictionary<string, bool> Tags { get; set; }
+        public IDictionary<string, string> DimensionValues { get; set; }
     }
 }

--- a/KachingPlugIn/ViewModels/PlugInViewModel.cs
+++ b/KachingPlugIn/ViewModels/PlugInViewModel.cs
@@ -2,12 +2,12 @@
 {
     public class PlugInViewModel
     {
+        public bool ExportSingleVariantAsProduct { get; set; }
         public string ProductsImportUrl { get; set; }
         public string TagsImportUrl { get; set; }
         public string FoldersImportUrl { get; set; }
         public bool ProductExportStartButtonDisabled { get; set; }
         public bool CategoryExportStartButtonDisabled { get; set; }
         public ProgressViewModel ProgressViewModel { get; set; }
-        public string ProgressViewLocation { get; set; }
     }
 }

--- a/KachingPlugIn/Views/KachingPlugIn/Index.cshtml
+++ b/KachingPlugIn/Views/KachingPlugIn/Index.cshtml
@@ -10,49 +10,54 @@
 <html>
 <head>
     <title>Ka-ching integration</title>
+    <link type="text/css" rel="stylesheet" href="@Paths.ToShellClientResource("ClientResources/epi/themes/legacy/ShellCore.css")" />
+    <link type="text/css" rel="stylesheet" href="@Paths.ToShellClientResource("ClientResources/epi/themes/legacy/ShellCoreLightTheme.css")" />
+    <link type="text/css" rel="stylesheet" href="@Paths.ToResource("CMS", "App_Themes/Default/Styles/system.css")" />
 </head>
 
 <body>
-    <div>
-        <h2>Ka-ching integration</h2>
-
-        <hr />
+    <div class="epi-contentContainer epi-padding">
+        <div class="epi-contentArea">
+            <h1 class="EP-prefix">Ka-ching integration</h1>
+        </div>
 
         @if (Model.ProgressViewModel.Busy)
         {
             <div id="progress">
-                @Html.Partial(Paths.ToResource("KachingPlugIn", "KachingPlugIn/Views/Progress.cshtml"), Model.ProgressViewModel)
+                @Html.Partial(Paths.ToResource("KachingPlugIn", "Views/Progress.cshtml"), Model.ProgressViewModel)
             </div>
         }
         else
         {
-            @using (Html.BeginForm("UpdateConfiguration", "KachingPlugIn", FormMethod.Post))
-            {
-                <fieldset>
-                    <legend>Import settings</legend>
-                </fieldset>
-                <div class="epi-size10">
-                    <div>
-                        @Html.LabelFor(m => m.ExportSingleVariantAsProduct, "Export single variants as product?")
-                        @Html.CheckBoxFor(m => m.ExportSingleVariantAsProduct)
-                    </div>
-                    <div>
-                        @Html.LabelFor(m => m.ProductsImportUrl, "Products import URL")
-                        @Html.TextBoxFor(m => m.ProductsImportUrl)
-                    </div>
-                    <div>
-                        @Html.LabelFor(m => m.FoldersImportUrl, "Folders import URL")
-                        @Html.TextBoxFor(m => m.FoldersImportUrl)
-                    </div>
-                    <div>
-                        @Html.LabelFor(m => m.TagsImportUrl, "Tags import URL")
-                        @Html.TextBoxFor(m => m.TagsImportUrl)
-                    </div>
-                </div>
-                <div class="epi-buttonContainer-small">
-                    <button type="submit">Save</button>
-                </div>
-            }
+            <div class="epi-formArea">
+                @using (Html.BeginForm("UpdateConfiguration", "KachingPlugIn", FormMethod.Post))
+                {
+                    <fieldset>
+                        <legend>Import settings</legend>
+                        <div class="epi-size10">
+                            <div>
+                                @Html.LabelFor(m => m.ExportSingleVariantAsProduct, "Export single variants as product?")
+                                @Html.CheckBoxFor(m => m.ExportSingleVariantAsProduct)
+                            </div>
+                            <div>
+                                @Html.LabelFor(m => m.ProductsImportUrl, "Products import URL")
+                                @Html.TextBoxFor(m => m.ProductsImportUrl)
+                            </div>
+                            <div>
+                                @Html.LabelFor(m => m.FoldersImportUrl, "Folders import URL")
+                                @Html.TextBoxFor(m => m.FoldersImportUrl)
+                            </div>
+                            <div>
+                                @Html.LabelFor(m => m.TagsImportUrl, "Tags import URL")
+                                @Html.TextBoxFor(m => m.TagsImportUrl)
+                            </div>
+                        </div>
+                        <div class="epi-buttonContainer-small">
+                            <button type="submit">Save</button>
+                        </div>
+                    </fieldset>
+                }
+            </div>
 
             <br />
             <hr />

--- a/KachingPlugIn/Views/KachingPlugIn/Index.cshtml
+++ b/KachingPlugIn/Views/KachingPlugIn/Index.cshtml
@@ -1,12 +1,12 @@
 ﻿@using System.Web.Mvc
 @using System.Web.Mvc.Html
+@using EPiServer.Shell
 @inherits System.Web.Mvc.WebViewPage<KachingPlugIn.ViewModels.PlugInViewModel>
 @{
     Layout = null;
 }
 
 <!DOCTYPE html>
-
 <html>
 <head>
     <title>Ka-ching integration</title>
@@ -21,41 +21,48 @@
         @if (Model.ProgressViewModel.Busy)
         {
             <div id="progress">
-                @Html.Partial(Model.ProgressViewLocation, Model.ProgressViewModel)
+                @Html.Partial(Paths.ToResource("KachingPlugIn", "KachingPlugIn/Views/Progress.cshtml"), Model.ProgressViewModel)
             </div>
         }
         else
         {
-            <h3>Specify import URLs</h3>
-
-            using (Html.BeginForm("UpdateProductImportUrl", "KachingPlugIn", FormMethod.Post, new { @class = "form-inline" }))
+            @using (Html.BeginForm("UpdateConfiguration", "KachingPlugIn", FormMethod.Post))
             {
-                <p>Products import URL</p>
-                @Html.TextBoxFor(m => m.ProductsImportUrl)
-                <button type="submit">Save</button>
-            }
-            using (Html.BeginForm("UpdateTagsImportUrl", "KachingPlugIn", FormMethod.Post, new { @class = "form-inline" }))
-            {
-                <p>Tags import URL</p>
-                @Html.TextBoxFor(m => m.TagsImportUrl)
-                <button type="submit">Save</button>
-            }
-            using (Html.BeginForm("UpdateFoldersImportUrl", "KachingPlugIn", FormMethod.Post, new { @class = "form-inline" }))
-            {
-                <p>Folders import URL</p>
-                @Html.TextBoxFor(m => m.FoldersImportUrl)
-                <button type="submit">Save</button>
+                <fieldset>
+                    <legend>Import settings</legend>
+                </fieldset>
+                <div class="epi-size10">
+                    <div>
+                        @Html.LabelFor(m => m.ExportSingleVariantAsProduct, "Export single variants as product?")
+                        @Html.CheckBoxFor(m => m.ExportSingleVariantAsProduct)
+                    </div>
+                    <div>
+                        @Html.LabelFor(m => m.ProductsImportUrl, "Products import URL")
+                        @Html.TextBoxFor(m => m.ProductsImportUrl)
+                    </div>
+                    <div>
+                        @Html.LabelFor(m => m.FoldersImportUrl, "Folders import URL")
+                        @Html.TextBoxFor(m => m.FoldersImportUrl)
+                    </div>
+                    <div>
+                        @Html.LabelFor(m => m.TagsImportUrl, "Tags import URL")
+                        @Html.TextBoxFor(m => m.TagsImportUrl)
+                    </div>
+                </div>
+                <div class="epi-buttonContainer-small">
+                    <button type="submit">Save</button>
+                </div>
             }
 
             <br />
             <hr />
 
-            using (Html.BeginForm("StartFullProductExport", "KachingPlugIn", FormMethod.Post, new { @class = "form-inline" }))
+            using (Html.BeginForm("StartFullProductExport", "KachingPlugIn", FormMethod.Post))
             {
                 <h3>Perform full product export</h3>
                 if (Model.ProductExportStartButtonDisabled)
                 {
-                    <p><em>Attention:</em> Requires valid products import URL. Find the URL in <a href="https://backoffice.ka-ching.dk" target="_blank"> Ka-ching Backoffice</a></p>
+                    <p><em>Attention:</em> Requires valid products import URL. Find the URL in <a href="https://backoffice.ka-ching.dk" target="_blank">Ka-ching Backoffice</a></p>
                 }
                 <button type="submit" onclick="scheduleReloadProgressElement();" disabled='@(Model.ProductExportStartButtonDisabled)'>Start</button>
             }
@@ -63,12 +70,12 @@
             <br />
             <hr />
 
-            using (Html.BeginForm("StartFullCategoryExport", "KachingPlugIn", FormMethod.Post, new { @class = "form-inline" }))
+            using (Html.BeginForm("StartFullCategoryExport", "KachingPlugIn", FormMethod.Post))
             {
                 <h3>Perform full category export</h3>
                 if (Model.CategoryExportStartButtonDisabled)
                 {
-                    <p><em>Attention:</em> Requires valid tags and folders import URLs. Find the URLs in <a href="https://backoffice.ka-ching.dk" target="_blank"> Ka-ching Backoffice</a></p>
+                    <p><em>Attention:</em> Requires valid tags and folders import URLs. Find the URLs in <a href="https://backoffice.ka-ching.dk" target="_blank">Ka-ching Backoffice</a></p>
                 }
                 <button type="submit" onclick="scheduleReloadProgressElement();" disabled='@(Model.CategoryExportStartButtonDisabled)'>Start</button>
             }


### PR DESCRIPTION
This pull request contains changes that allows a product with a single variant to be exported as a product, only.
Normally this scenario would export a product with a single variant. But if the solution needs to skip the variant level (because there are only one variant for each product), this "collapsing" can now be enabled on the plugin configuration page.

Changes:
- Extend configuration data model.
- Extend plugin configuration page.
- Rewrite plugin configuration controller (fewer actions) and view (using standard Episerver styling).
- Extend ProductFactory class with new logic.
