### PR TITLE
Exclude disabled markets from export

### DIFF
--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -228,7 +228,7 @@ namespace KachingPlugIn.Factories
 
             foreach (var market in markets)
             {
-                if (market.IsEnabled)
+                if (!market.IsEnabled)
                 {
                     continue;
                 }

--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -251,37 +251,39 @@ namespace KachingPlugIn.Factories
 
         private MarketPrice MarketPriceForCode(string code)
         {
-            /* ---------------------------- */
-            /* Find prices for all markets */
-            /* ---------------------------- */
-
             var markets = _marketService.GetAllMarkets();
             var prices = new Dictionary<string, decimal>();
+
+            ICollection<IPriceValue> allPriceValues = _priceService
+                .GetPrices(
+                    MarketId.Empty,
+                    DateTime.UtcNow,
+                    new CatalogKey(code),
+                    new PriceFilter())
+                .ToArray();
+
             foreach (var market in markets)
             {
-                var filter = new PriceFilter()
+                if (!market.IsEnabled)
                 {
-                    Currencies = new Currency[] { market.DefaultCurrency }
-                };
-
-                var price = _priceService.GetPrices(
-                    market.MarketId,
-                    DateTime.Now,
-                    new CatalogKey(code),
-                    filter)
-                    .FirstOrDefault();
-                if (price != null && market.MarketId != null)
-                {
-                    var marketKey = market.MarketId.Value.KachingCompatibleKey();
-                    prices[marketKey] = price.UnitPrice.Amount;
+                    continue;
                 }
+
+                var priceValue = allPriceValues.FirstOrDefault(pv =>
+                    pv.MarketId == market.MarketId &&
+                    pv.UnitPrice.Currency == market.DefaultCurrency);
+                if (priceValue == null)
+                {
+                    continue;
+                }
+
+                var marketKey = market.MarketId.Value.KachingCompatibleKey();
+                prices[marketKey] = priceValue.UnitPrice.Amount;
             }
 
-            if (prices.Count == 0)
-            {
-                return null;
-            }
-            return new MarketPrice(prices);
+            return prices.Count == 0
+                ? null
+                : new MarketPrice(prices);
         }
     }
 }

--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -225,16 +225,27 @@ namespace KachingPlugIn.Factories
         {
             var markets = _marketService.GetAllMarkets();
             var kachingMarkets = new Dictionary<string, bool>();
+
             foreach (var market in markets)
             {
+                if (market.IsEnabled)
+                {
+                    continue;
+                }
+
                 var marketKey = market.MarketId.Value.KachingCompatibleKey();
                 kachingMarkets[marketKey] = true;
             }
 
-            var result = new ProductMetadata();
-            result.Channels = new Dictionary<string, bool>();
-            result.Channels["pos"] = true;
-            result.Markets = kachingMarkets;
+            var result = new ProductMetadata
+            {
+                Markets = kachingMarkets,
+                Channels = new Dictionary<string, bool>(1)
+                {
+                    ["pos"] = true
+                }
+            };
+
             return result;
         }
 


### PR DESCRIPTION
On exporting products/variants and their prices, disabled markets are also exported.
This pull requests skips disabled markets from two places.

It also optimizes the price loading, batch-loading all price values for a given entry code. This can be further optimized in the future.