### PR TITLE
Implement static API key authentication middleware

### DIFF
--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -64,6 +64,13 @@
     <Compile Include="KachingPlugIn\Services\ProductExportSingleton.cs" />
     <Compile Include="KachingPlugIn\ViewModels\PlugInViewModel.cs" />
     <Compile Include="KachingPlugIn\ViewModels\ProgressViewModel.cs" />
+    <Compile Include="Owin\KachingApiAuthenticationExtensions.cs" />
+    <Compile Include="Owin\KachingApiAuthenticationHandler.cs" />
+    <Compile Include="Owin\KachingApiAuthenticationMiddleware.cs" />
+    <Compile Include="Owin\KachingApiAuthenticationOptions.cs" />
+    <Compile Include="Owin\KachingApiAuthenticationProvider.cs" />
+    <Compile Include="Owin\KachingApiDefaults.cs" />
+    <Compile Include="Owin\KachingApiValidateIdentityContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -203,11 +203,20 @@
     <Reference Include="Mediachase.WebConsoleLib, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/KachingPlugIn.nuspec
+++ b/KachingPlugIn.nuspec
@@ -15,6 +15,7 @@
       <dependency id="EPiServer.CMS.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.CMS.UI.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.Commerce.Core" version="[13.0.0,14.0.0)" />
+      <dependency id="Microsoft.Owin.Security" version="4.0.0" />
       <dependency id="Newtonsoft.Json" version="11.0.1" />
     </dependencies>
   </metadata>

--- a/Owin/KachingApiAuthenticationExtensions.cs
+++ b/Owin/KachingApiAuthenticationExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.Owin.Extensions;
+using Owin;
+
+namespace KachingPlugIn.Owin
+{
+    public static class KachingApiAuthenticationExtensions
+    {
+        public static IAppBuilder UseKachingApiKeyAuthentication(
+            this IAppBuilder app,
+            KachingApiAuthenticationOptions options)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            app.Use(
+                typeof(KachingApiAuthenticationMiddleware),
+                app,
+                options ?? new KachingApiAuthenticationOptions());
+            app.UseStageMarker(PipelineStage.Authenticate);
+
+            return app;
+        }
+    }
+}

--- a/Owin/KachingApiAuthenticationHandler.cs
+++ b/Owin/KachingApiAuthenticationHandler.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Infrastructure;
+
+namespace KachingPlugIn.Owin
+{
+    public class KachingApiAuthenticationHandler : AuthenticationHandler<KachingApiAuthenticationOptions>
+    {
+        private readonly ILogger _logger;
+
+        public KachingApiAuthenticationHandler(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(Options.ApiKey))
+                {
+                    return null;
+                }
+
+                string token = null;
+                string headerValue = Request.Headers.Get("Authorization");
+
+                if (!string.IsNullOrEmpty(headerValue) &&
+                    headerValue.StartsWith("KachingKey ", StringComparison.OrdinalIgnoreCase))
+                {
+                    token = headerValue.Substring("KachingKey ".Length).Trim();
+                }
+
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    return null;
+                }
+
+                var validateIdentityContext = new KachingApiValidateIdentityContext(Context, token);
+                if (Options.Provider != null)
+                {
+                    await Options.Provider.ValidateIdentity(validateIdentityContext);
+                }
+
+                if (!validateIdentityContext.IsValidated)
+                {
+                    return null;
+                }
+
+                var identity = new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.Name, Options.UserName),
+                        new Claim(ClaimTypes.Role, Options.RoleName)
+                    },
+                    Options.AuthenticationType);
+
+                var ticket = new AuthenticationTicket(identity, new AuthenticationProperties());
+
+                return ticket;
+            }
+            catch (Exception error)
+            {
+                _logger.WriteError("Authentication failed", error);
+
+                return null;
+            }
+        }
+    }
+}

--- a/Owin/KachingApiAuthenticationMiddleware.cs
+++ b/Owin/KachingApiAuthenticationMiddleware.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security.Infrastructure;
+using Owin;
+
+namespace KachingPlugIn.Owin
+{
+    public class KachingApiAuthenticationMiddleware : AuthenticationMiddleware<KachingApiAuthenticationOptions>
+    {
+        private readonly ILogger _logger;
+
+        public KachingApiAuthenticationMiddleware(
+            OwinMiddleware next,
+            IAppBuilder app,
+            KachingApiAuthenticationOptions options)
+            : base(next, options)
+        {
+            _logger = app.CreateLogger<KachingApiAuthenticationMiddleware>();
+
+            if (Options.Provider == null)
+            {
+                Options.Provider = new KachingApiAuthenticationProvider
+                {
+                    OnValidateIdentity = context =>
+                    {
+                        if (string.Equals(context.ApiKey, Options.ApiKey, StringComparison.Ordinal))
+                        {
+                            context.Validate();
+                        }
+
+                        return Task.FromResult(0);
+                    }
+                };
+            }
+        }
+
+        protected override AuthenticationHandler<KachingApiAuthenticationOptions> CreateHandler()
+        {
+            return new KachingApiAuthenticationHandler(_logger);
+        }
+    }
+}

--- a/Owin/KachingApiAuthenticationOptions.cs
+++ b/Owin/KachingApiAuthenticationOptions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Owin.Security;
+
+namespace KachingPlugIn.Owin
+{
+    public class KachingApiAuthenticationOptions : AuthenticationOptions
+    {
+        public KachingApiAuthenticationOptions()
+            : this(KachingApiDefaults.AuthenticationType)
+        {
+        }
+
+        public KachingApiAuthenticationOptions(string authenticationType)
+            : base(authenticationType)
+        {
+            RoleName = KachingApiDefaults.RoleName;
+            UserName = KachingApiDefaults.UserName;
+        }
+
+        public string ApiKey { get; set; }
+
+        public string RoleName { get; set; }
+
+        public string UserName { get; set; }
+
+        public KachingApiAuthenticationProvider Provider { get; set; }
+    }
+}

--- a/Owin/KachingApiAuthenticationProvider.cs
+++ b/Owin/KachingApiAuthenticationProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace KachingPlugIn.Owin
+{
+    public class KachingApiAuthenticationProvider
+    {
+        public KachingApiAuthenticationProvider()
+        {
+            OnValidateIdentity = context => Task.FromResult<object>(null);
+        }
+
+        public Func<KachingApiValidateIdentityContext, Task> OnValidateIdentity { get; set; }
+
+        public virtual Task ValidateIdentity(KachingApiValidateIdentityContext context)
+        {
+            return OnValidateIdentity(context);
+        }
+    }
+}

--- a/Owin/KachingApiDefaults.cs
+++ b/Owin/KachingApiDefaults.cs
@@ -1,0 +1,9 @@
+﻿namespace KachingPlugIn.Owin
+{
+    public class KachingApiDefaults
+    {
+        public const string AuthenticationType = "KachingAPI";
+        public const string UserName = "Kaching";
+        public const string RoleName = "Kaching";
+    }
+}

--- a/Owin/KachingApiValidateIdentityContext.cs
+++ b/Owin/KachingApiValidateIdentityContext.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Security.Provider;
+
+namespace KachingPlugIn.Owin
+{
+    public class KachingApiValidateIdentityContext : BaseContext
+    {
+        public KachingApiValidateIdentityContext(IOwinContext context, string apiKey)
+            : base(context)
+        {
+            ApiKey = apiKey;
+        }
+
+        public string ApiKey { get; protected set; }
+
+        public bool IsValidated { get; private set; }
+
+        protected bool HasError { get; set; }
+
+        public void Validate()
+        {
+            HasError = false;
+            IsValidated = true;
+        }
+    }
+}

--- a/packages.config
+++ b/packages.config
@@ -13,9 +13,12 @@
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net461" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net461" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net461" />


### PR DESCRIPTION
For incoming API requests required by upcoming features, this pull requests implement a static API key authentication middleware.

In Ka-ching, all export and runtime integrations can then be configured with an Authorization header, like this:
```
Authorization: KachingKey 24E40822-228C-4D56-9BCD-9D99D2C10716
```

The middleware can be added to the OWIN pipeline, like this:
```
app.UseKachingApiKeyAuthentication(
    new KachingApiAuthenticationOptions
    {
        ApiKey = "24E40822-228C-4D56-9BCD-9D99D2C10716"
    });
```

The ApiKey property can also be set by a configuration entry, using ConfigurationManager, like this:
```
app.UseKachingApiKeyAuthentication(
    new KachingApiAuthenticationOptions
    {
        ApiKey = ConfigurationManager.AppSettings["Kaching:ApiKey"]
    });
```