### PR TITLE
Implement customer lookup API

### DIFF
--- a/Customers/CustomerViewModel.cs
+++ b/Customers/CustomerViewModel.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+
+namespace KachingPlugIn.Customers
+{
+    public class CustomerViewModel
+    {
+        [JsonProperty("identifier")]
+        public string Identifier { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("street")]
+        public string Street { get; set; }
+
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        [JsonProperty("postal_code")]
+        public string PostalCode { get; set; }
+
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
+
+        [JsonProperty("phone")]
+        public string Phone { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("additional_info")]
+        public string AdditionalInfo { get; set; }
+    }
+}

--- a/Customers/CustomerViewModelFactory.cs
+++ b/Customers/CustomerViewModelFactory.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EPiServer.ServiceLocation;
+using Mediachase.Commerce.Customers;
+
+namespace KachingPlugIn.Customers
+{
+    [ServiceConfiguration(typeof(CustomerViewModelFactory))]
+    public class CustomerViewModelFactory
+    {
+        public virtual IEnumerable<CustomerViewModel> Create(IEnumerable<CustomerContact> contacts)
+        {
+            if (contacts == null)
+            {
+                yield break;
+            }
+
+            foreach (CustomerContact contact in contacts)
+            {
+                CustomerAddress shippingAddress = contact.ContactAddresses.FirstOrDefault(
+                    a => (a.AddressType & CustomerAddressTypeEnum.Shipping) == CustomerAddressTypeEnum.Shipping);
+
+                var viewModel = new CustomerViewModel
+                {
+                    Identifier = contact.Email,
+                    Name = contact.FullName,
+                    Street = shippingAddress?.Line1 +
+                             (!string.IsNullOrWhiteSpace(shippingAddress?.Line2) ? ", "+ shippingAddress.Line2 : null),
+                    PostalCode = shippingAddress?.PostalCode,
+                    City = shippingAddress?.City,
+                    Country = shippingAddress?.CountryName,
+                    CountryCode = shippingAddress?.CountryCode,
+                    Email = shippingAddress?.Email ?? contact.Email,
+                    Phone = shippingAddress?.DaytimePhoneNumber
+                };
+
+                yield return viewModel;
+            }
+        }
+    }
+} 

--- a/Customers/CustomersController.cs
+++ b/Customers/CustomersController.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Web.Http;
+using Mediachase.Commerce.Customers;
+
+namespace KachingPlugIn.Customers
+{
+    [Authorize(Roles = "Kaching")]
+    public class CustomerLookupController : ApiController
+    {
+        private readonly CustomerViewModelFactory _customerViewModelFactory;
+
+        public CustomerLookupController(CustomerViewModelFactory customerViewModelFactory)
+        {
+            _customerViewModelFactory = customerViewModelFactory;
+        }
+
+        [HttpGet]
+        public IHttpActionResult GetAllCustomers(string q)
+        {
+            IEnumerable<CustomerContact> contacts = CustomerContext.Current.GetContactsByPattern(q);
+
+            IEnumerable<CustomerViewModel> viewModels = _customerViewModelFactory.Create(contacts);
+
+            return Json(viewModels);
+        }
+    }
+}

--- a/Infrastructure/WebApiInitialization.cs
+++ b/Infrastructure/WebApiInitialization.cs
@@ -1,0 +1,27 @@
+﻿using System.Web.Http;
+using EPiServer.Framework;
+using EPiServer.Framework.Initialization;
+using EPiServer.ServiceLocation;
+
+namespace KachingPlugIn.Infrastructure
+{
+    [InitializableModule]
+    public class WebApiInitialization : IConfigurableModule
+    {
+        public void Initialize(InitializationEngine context)
+        {
+        }
+
+        public void Uninitialize(InitializationEngine context)
+        {
+        }
+
+        public void ConfigureContainer(ServiceConfigurationContext context)
+        {
+            GlobalConfiguration.Configuration.Routes.MapHttpRoute(
+                "DefaultKachingRoute",
+                "api/kaching/{controller}/{id}",
+                new {id = RouteParameter.Optional});
+        }
+    }
+}

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -35,6 +35,10 @@
     <Compile Include="Configuration\AttributeMappingElement.cs" />
     <Compile Include="Configuration\KachingConfiguration.cs" />
     <Compile Include="Configuration\SystemMappingElement.cs" />
+    <Compile Include="Customers\CustomersController.cs" />
+    <Compile Include="Customers\CustomerViewModel.cs" />
+    <Compile Include="Customers\CustomerViewModelFactory.cs" />
+    <Compile Include="Infrastructure\WebApiInitialization.cs" />
     <Compile Include="KachingPlugIn\Controllers\KachingPlugInController.cs" />
     <Compile Include="KachingPlugIn\EventHandlers\CatalogEventHandler.cs" />
     <Compile Include="KachingPlugIn\Factories\ProductFactory.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -223,6 +223,9 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -250,6 +253,12 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>

--- a/KachingPlugIn.nuspec
+++ b/KachingPlugIn.nuspec
@@ -15,6 +15,7 @@
       <dependency id="EPiServer.CMS.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.CMS.UI.Core" version="[11.0.0,12.0.0)" />
       <dependency id="EPiServer.Commerce.Core" version="[13.0.0,14.0.0)" />
+      <dependency id="Microsoft.AspNet.WebApi" version="5.2.0" />
       <dependency id="Newtonsoft.Json" version="11.0.1" />
     </dependencies>
   </metadata>

--- a/packages.config
+++ b/packages.config
@@ -12,6 +12,10 @@
   <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />


### PR DESCRIPTION
This pull request implements a simple customer lookup API for Episerver.

The URL to this endpoint is: `/api/kaching/customerlookup?q={free-text query}`.
All requests need authorization as a user with the `Kaching` role.

When calling this endpoint with a GET request, it will search through all text properties on the `CustomerContact` entities.