### PR TITLE
Implement export of product assets

### DIFF
--- a/Configuration/KachingConfiguration.cs
+++ b/Configuration/KachingConfiguration.cs
@@ -12,6 +12,9 @@ namespace KachingPlugIn.Configuration
         [ConfigurationProperty("productsImportUrl", IsRequired = true)]
         public string ProductsImportUrl => (string)base["productsImportUrl"];
 
+        [ConfigurationProperty("productAssetsImportUrl", IsRequired = false)]
+        public string ProductAssetsImportUrl => (string)base["productAssetsImportUrl"];
+
         [ConfigurationProperty("tagsImportUrl", IsRequired = false)]
         public string TagsImportUrl => (string)base["tagsImportUrl"];
 

--- a/EnumerableExtensions.cs
+++ b/EnumerableExtensions.cs
@@ -4,7 +4,9 @@ namespace KachingPlugIn
 {
     public static class EnumerableExtensions
     {
-        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> collection, int batchSize)
+        public static IEnumerable<IEnumerable<T>> Batch<T>(
+            this IEnumerable<T> collection,
+            int batchSize)
         {
             List<T> nextBatch = new List<T>(batchSize);
             foreach (T item in collection)
@@ -19,6 +21,32 @@ namespace KachingPlugIn
                 yield return nextBatch;
 
                 nextBatch = new List<T>(batchSize);
+            }
+
+            if (nextBatch.Count > 0)
+            {
+                yield return nextBatch;
+            }
+        }
+
+        public static IEnumerable<IDictionary<TKey, TValue>> Batch<TKey, TValue>(
+            this IDictionary<TKey, TValue> collection,
+            int batchSize)
+        {
+            IDictionary<TKey, TValue> nextBatch = new Dictionary<TKey, TValue>(batchSize);
+
+            foreach (KeyValuePair<TKey, TValue> item in collection)
+            {
+                nextBatch.Add(item);
+
+                if (nextBatch.Count < batchSize)
+                {
+                    continue;
+                }
+
+                yield return nextBatch;
+
+                nextBatch = new Dictionary<TKey, TValue>(batchSize);
             }
 
             if (nextBatch.Count > 0)

--- a/EnumerableExtensions.cs
+++ b/EnumerableExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace KachingPlugIn
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> collection, int batchSize)
+        {
+            List<T> nextBatch = new List<T>(batchSize);
+            foreach (T item in collection)
+            {
+                nextBatch.Add(item);
+
+                if (nextBatch.Count < batchSize)
+                {
+                    continue;
+                }
+
+                yield return nextBatch;
+
+                nextBatch = new List<T>(batchSize);
+            }
+
+            if (nextBatch.Count > 0)
+            {
+                yield return nextBatch;
+            }
+        }
+    }
+}

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -52,6 +52,7 @@
     <Compile Include="KachingPlugIn\Models\MarketPriceConverter.cs" />
     <Compile Include="KachingPlugIn\Models\PriceUnit.cs" />
     <Compile Include="KachingPlugIn\Models\Product.cs" />
+    <Compile Include="KachingPlugIn\Models\ProductAsset.cs" />
     <Compile Include="KachingPlugIn\Models\Tag.cs" />
     <Compile Include="KachingPlugIn\Models\L10nString.cs" />
     <Compile Include="KachingPlugIn\Models\MarketPrice.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Configuration\AttributeMappingElement.cs" />
     <Compile Include="Configuration\KachingConfiguration.cs" />
     <Compile Include="Configuration\SystemMappingElement.cs" />
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="KachingPlugIn\Controllers\KachingPlugInController.cs" />
     <Compile Include="KachingPlugIn\EventHandlers\CatalogEventHandler.cs" />
     <Compile Include="KachingPlugIn\Factories\ProductFactory.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Configuration\KachingConfiguration.cs" />
     <Compile Include="Configuration\SystemMappingElement.cs" />
     <Compile Include="EnumerableExtensions.cs" />
+    <Compile Include="KachingPlugIn\CommerceMediaComparer.cs" />
     <Compile Include="KachingPlugIn\Controllers\KachingPlugInController.cs" />
     <Compile Include="KachingPlugIn\EventHandlers\CatalogEventHandler.cs" />
     <Compile Include="KachingPlugIn\Factories\ProductFactory.cs" />

--- a/KachingPlugIn/CommerceMediaComparer.cs
+++ b/KachingPlugIn/CommerceMediaComparer.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using EPiServer.Commerce.SpecializedProperties;
+using EPiServer.Core;
+
+namespace KachingPlugIn.KachingPlugIn
+{
+    public class CommerceMediaComparer : IEqualityComparer<CommerceMedia>
+    {
+        public static readonly CommerceMediaComparer Default = new CommerceMediaComparer();
+
+        public bool Equals(CommerceMedia x, CommerceMedia y)
+        {
+            return ContentReferenceComparer.IgnoreVersion.Equals(x?.AssetLink, y?.AssetLink);
+        }
+
+        public int GetHashCode(CommerceMedia obj)
+        {
+            return ContentReferenceComparer.IgnoreVersion.GetHashCode();
+        }
+    }
+}

--- a/KachingPlugIn/EventHandlers/CatalogEventHandler.cs
+++ b/KachingPlugIn/EventHandlers/CatalogEventHandler.cs
@@ -3,7 +3,6 @@ using EPiServer.Commerce.Catalog.ContentTypes;
 using EPiServer.Core;
 using EPiServer.Logging;
 using KachingPlugIn.Helpers;
-using KachingPlugIn.Models;
 using KachingPlugIn.Services;
 using Mediachase.Commerce.Catalog;
 using Mediachase.Commerce.Engine.Events;
@@ -197,7 +196,7 @@ namespace KachingPlugIn.EventHandlers
                     }
                     else
                     {
-                        _log.Warning("Price changed on unhandled type: " + content.GetType().ToString());
+                        _log.Warning("Price changed on unhandled type: " + content.GetType());
                     }
                 }
             }
@@ -222,10 +221,12 @@ namespace KachingPlugIn.EventHandlers
             if (isDelete)
             {
                 _productExportService.DeleteProduct(product, configuration.ProductsImportUrl);
+                _productExportService.DeleteProductAssets(new[] {product.Code.KachingCompatibleKey()});
             }
             else
             {
                 _productExportService.ExportProduct(product, deletedVariantCode, configuration.ProductsImportUrl);
+                _productExportService.ExportProductAssets(new[] {product});
             }
         }
 
@@ -247,7 +248,7 @@ namespace KachingPlugIn.EventHandlers
 
         private void HandleCategoryChange(NodeContent node, ChangeType changeType)
         {
-            _log.Information("HandleCategoryChange - type: " + changeType.ToString() + " code: " + node.Code);
+            _log.Information("HandleCategoryChange - type: " + changeType + " code: " + node.Code);
             // Make sure we have valid import endpoints configured before handling the change
             var configuration = KachingConfiguration.Instance;
             if (!configuration.TagsImportUrl.IsValidTagsImportUrl() || 

--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -226,6 +226,38 @@ namespace KachingPlugIn.Factories
             return kachingProduct;
         }
 
+        public IEnumerable<ProductAsset> BuildKaChingProductAssets(EntryContentBase entryContent)
+        {
+            foreach (CommerceMedia media in entryContent.CommerceMediaCollection)
+            {
+                MediaData mediaData = _contentLoader.Get<MediaData>(media.AssetLink);
+                Uri absoluteUrl = GetAbsoluteUrl(media.AssetLink);
+
+                string mimeType;
+                switch (mediaData.MimeType)
+                {
+                    case "application/pdf":
+                        mimeType = "document/pdf";
+                        break;
+                    case "image/jpeg":
+                    case "image/png":
+                        mimeType = mediaData.MimeType;
+                        break;
+                    default:
+                        continue;
+                }
+
+                var asset = new ProductAsset
+                {
+                    MimeType = mimeType,
+                    Name = new L10nString(mediaData.Name),
+                    Url = absoluteUrl.ToString()
+                };
+
+                yield return asset;
+            }
+        }
+
         public ProductMetadata ProductMetadata()
         {
             var markets = _marketService.GetAllMarkets();

--- a/KachingPlugIn/Factories/ProductFactory.cs
+++ b/KachingPlugIn/Factories/ProductFactory.cs
@@ -57,7 +57,7 @@ namespace KachingPlugIn.Factories
         {
             var kachingProduct = new Product();
 
-            kachingProduct.Id = product.Code;
+            kachingProduct.Id = product.Code.KachingCompatibleKey();
             kachingProduct.Barcode = GetPropertyStringValue(product, configuration.SystemMappings.BarcodeMetaField);
             kachingProduct.Name = _l10nStringFactory.GetLocalizedString(product, nameof(product.DisplayName));
             kachingProduct.Description = _l10nStringFactory.GetLocalizedString(product, configuration.SystemMappings.DescriptionMetaField);
@@ -129,7 +129,7 @@ namespace KachingPlugIn.Factories
                 // then put all variant properties on the product instead.
                 var variant = variants.First();
 
-                kachingProduct.Id = variant.Code;
+                kachingProduct.Id = variant.Code.KachingCompatibleKey();
                 kachingProduct.Barcode = GetPropertyStringValue(variant, configuration.SystemMappings.BarcodeMetaField);
                 kachingProduct.Name = _l10nStringFactory.GetLocalizedString(variant, nameof(variant.DisplayName));
 
@@ -170,7 +170,7 @@ namespace KachingPlugIn.Factories
                     }
 
                     var kachingVariant = new Variant();
-                    kachingVariant.Id = variant.Code;
+                    kachingVariant.Id = variant.Code.KachingCompatibleKey();
                     kachingVariant.Barcode = GetPropertyStringValue(variant, configuration.SystemMappings.BarcodeMetaField);
 
                     var variantName = _l10nStringFactory.GetLocalizedString(variant, nameof(variant.DisplayName));

--- a/KachingPlugIn/Helpers/APIFacade.cs
+++ b/KachingPlugIn/Helpers/APIFacade.cs
@@ -11,9 +11,9 @@ namespace KachingPlugIn.Helpers
     {
         private static readonly ILogger _log = LogManager.GetLogger(typeof(APIFacade));
 
-        public static HttpStatusCode Delete(IList<string> ids, string url)
+        public static HttpStatusCode Delete(IEnumerable<string> ids, string url)
         {
-            var deleteUrl = url + "&ids=" + string.Join(",", ids);
+            string deleteUrl = url + "&ids=" + string.Join(",", ids);
             _log.Information("Delete url: " + deleteUrl);
 
             WebRequest request = WebRequest.Create(deleteUrl);

--- a/KachingPlugIn/Helpers/StringExtensions.cs
+++ b/KachingPlugIn/Helpers/StringExtensions.cs
@@ -18,6 +18,11 @@ namespace KachingPlugIn.Helpers
                 .Replace('#', '_');
         }
 
+        public static bool IsValidProductAssetsImportUrl(this string url)
+        {
+            return IsValidUrl(url, "product_assets");
+        }
+
         public static bool IsValidProductsImportUrl(this string url)
         {
             return IsValidUrl(url, "products");
@@ -35,6 +40,12 @@ namespace KachingPlugIn.Helpers
 
         private static bool IsValidUrl(string url, string path)
         {
+            if (string.IsNullOrWhiteSpace(url) ||
+                string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
             Uri uriResult;
             if (Uri.TryCreate(url, UriKind.Absolute, out uriResult))
             {

--- a/KachingPlugIn/Models/ProductAsset.cs
+++ b/KachingPlugIn/Models/ProductAsset.cs
@@ -1,0 +1,17 @@
+﻿using KachingPlugIn.Models;
+using Newtonsoft.Json;
+
+namespace KachingPlugIn.KachingPlugIn.Models
+{
+    public class ProductAsset
+    {
+        [JsonProperty("mime_type")]
+        public string MimeType { get; set; }
+
+        [JsonProperty("name")]
+        public L10nString Name { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+}

--- a/web.config.install.xdt
+++ b/web.config.install.xdt
@@ -11,6 +11,7 @@
   </episerver.shell>
 
   <kaching productsImportUrl=""
+           productAssetsImportUrl=""
            foldersImportUrl=""
            tagsImportUrl=""
            exportSingleVariantAsProduct="false" xdt:Transform="InsertIfMissing">


### PR DESCRIPTION
This pull request implements export of product assets, on publish of individual products and on full product export.

Only assets that are added to the Asset field on a Product entry, will be exported.
Only JPEG, PNG and PDF files are currently supported on export. Any other type of asset will be silently ignored.