### PR TITLE
Implement export of curated product recommendations

### DIFF
--- a/Configuration/KachingConfiguration.cs
+++ b/Configuration/KachingConfiguration.cs
@@ -12,6 +12,9 @@ namespace KachingPlugIn.Configuration
         [ConfigurationProperty("productsImportUrl", IsRequired = true)]
         public string ProductsImportUrl => (string)base["productsImportUrl"];
 
+        [ConfigurationProperty("productRecommendationsImportUrl", IsRequired = false)]
+        public string ProductRecommendationsImportUrl => (string)base["productRecommendationsImportUrl"];
+
         [ConfigurationProperty("tagsImportUrl", IsRequired = false)]
         public string TagsImportUrl => (string)base["tagsImportUrl"];
 

--- a/EnumerableExtensions.cs
+++ b/EnumerableExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace KachingPlugIn
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> collection, int batchSize)
+        {
+            List<T> nextBatch = new List<T>(batchSize);
+            foreach (T item in collection)
+            {
+                nextBatch.Add(item);
+
+                if (nextBatch.Count < batchSize)
+                {
+                    continue;
+                }
+
+                yield return nextBatch;
+
+                nextBatch = new List<T>(batchSize);
+            }
+
+            if (nextBatch.Count > 0)
+            {
+                yield return nextBatch;
+            }
+        }
+    }
+}

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -52,6 +52,7 @@
     <Compile Include="KachingPlugIn\Models\MarketPriceConverter.cs" />
     <Compile Include="KachingPlugIn\Models\PriceUnit.cs" />
     <Compile Include="KachingPlugIn\Models\Product.cs" />
+    <Compile Include="KachingPlugIn\Models\RecommendationGroup.cs" />
     <Compile Include="KachingPlugIn\Models\Tag.cs" />
     <Compile Include="KachingPlugIn\Models\L10nString.cs" />
     <Compile Include="KachingPlugIn\Models\MarketPrice.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Configuration\AttributeMappingElement.cs" />
     <Compile Include="Configuration\KachingConfiguration.cs" />
     <Compile Include="Configuration\SystemMappingElement.cs" />
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="KachingPlugIn\Controllers\KachingPlugInController.cs" />
     <Compile Include="KachingPlugIn\EventHandlers\CatalogEventHandler.cs" />
     <Compile Include="KachingPlugIn\Factories\ProductFactory.cs" />

--- a/KachingPlugIn.csproj
+++ b/KachingPlugIn.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Configuration\SystemMappingElement.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="KachingPlugIn\Controllers\KachingPlugInController.cs" />
+    <Compile Include="KachingPlugIn\EventHandlers\AssociationsEventHandler.cs" />
     <Compile Include="KachingPlugIn\EventHandlers\CatalogEventHandler.cs" />
     <Compile Include="KachingPlugIn\Factories\ProductFactory.cs" />
     <Compile Include="KachingPlugIn\Factories\L10nStringFactory.cs" />

--- a/KachingPlugIn/EventHandlers/AssociationsEventHandler.cs
+++ b/KachingPlugIn/EventHandlers/AssociationsEventHandler.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EPiServer.Core;
+using EPiServer.Framework.Cache;
+using EPiServer.ServiceLocation;
+using KachingPlugIn.Services;
+using Mediachase.Commerce.Catalog;
+using Mediachase.Commerce.Catalog.Events;
+
+namespace KachingPlugIn.KachingPlugIn.EventHandlers
+{
+    [ServiceConfiguration(typeof(CatalogEventListenerBase), Lifecycle = ServiceInstanceScope.Singleton)]
+    public class AssociationsEventHandler : CatalogEventListenerBase
+    {
+        private readonly IObjectInstanceCache _cache;
+        private readonly ProductExportService _productExportService;
+        private readonly ReferenceConverter _referenceConverter;
+
+        public AssociationsEventHandler(
+            IObjectInstanceCache cache,
+            ProductExportService productExportService,
+            ReferenceConverter referenceConverter)
+        {
+            _cache = cache;
+            _productExportService = productExportService;
+            _referenceConverter = referenceConverter;
+        }
+
+        //public override void AssociationDeleted(object source, DeletedAssociationEventArgs args)
+        //{
+        //    ContentReference entryRef = _referenceConverter.GetContentLink(
+        //        args.ParentEntryId,
+        //        CatalogContentType.CatalogEntry,
+        //        0);
+
+        //    _productExportService.ExportProductRecommendations(new[] { entryRef });
+        //}
+
+        public override void AssociationUpdated(object source, AssociationEventArgs args)
+        {
+            // Get only one ContentReference per product, no matter how many changes are queued up for each.
+            ICollection<ContentReference> entryRefs = args.Changes
+                .GroupBy(ac => ac.ParentEntryId)
+                .Select(g => g.First())
+                .Select(ac =>
+                    _referenceConverter.GetContentLink(
+                        ac.ParentEntryId,
+                        CatalogContentType.CatalogEntry,
+                        0))
+                .ToArray();
+
+            if (entryRefs.Count == 0)
+            {
+                return;
+            }
+
+            // HACK: Episerver does not clear the deleted associations from cache until after this event has completed.
+            // In order to load the list of associations after deletions/updates, force delete the association list from cache.
+            foreach (ContentReference entryRef in entryRefs)
+            {
+                _cache.Remove("EP:ECF:Ass:" + entryRef.ID);
+            }
+
+            _productExportService.ExportProductRecommendations(entryRefs);
+        }
+    }
+}

--- a/KachingPlugIn/EventHandlers/CatalogEventHandler.cs
+++ b/KachingPlugIn/EventHandlers/CatalogEventHandler.cs
@@ -95,6 +95,7 @@ namespace KachingPlugIn.EventHandlers
                     var product = content as ProductContent;
                     _log.Information("Ka-ching event handler processing product deleting: " + product.Code);
                     HandleProductChange(product, true);
+                    _productExportService.DeleteProductRecommendations(product);
                 }
                 else if (content is NodeContent)
                 {
@@ -158,12 +159,14 @@ namespace KachingPlugIn.EventHandlers
                     var product = content as ProductContent;
                     _log.Information("Ka-ching event handler processing product publish: " + product.Code);
                     HandleProductChange(product, false);
+                    _productExportService.ExportProductRecommendations(product);
                 }
                 else if (content is NodeContent)
                 {
                     var node = content as NodeContent;
                     _log.Information("Ka-ching event handler processing category publish: " + node.Code);
                     HandleCategoryChange(node, ChangeType.Published);
+                    _productExportService.ExportProductRecommendations(node);
                 }
             }
             catch (Exception ex)
@@ -222,6 +225,7 @@ namespace KachingPlugIn.EventHandlers
             if (isDelete)
             {
                 _productExportService.DeleteProduct(product, configuration.ProductsImportUrl);
+                _productExportService.DeleteProductRecommendations(new[] { product.Code.KachingCompatibleKey() });
             }
             else
             {
@@ -250,7 +254,7 @@ namespace KachingPlugIn.EventHandlers
             _log.Information("HandleCategoryChange - type: " + changeType.ToString() + " code: " + node.Code);
             // Make sure we have valid import endpoints configured before handling the change
             var configuration = KachingConfiguration.Instance;
-            if (!configuration.TagsImportUrl.IsValidTagsImportUrl() || 
+            if (!configuration.TagsImportUrl.IsValidTagsImportUrl() ||
                 !configuration.FoldersImportUrl.IsValidFoldersImportUrl() ||
                 !configuration.ProductsImportUrl.IsValidProductsImportUrl())
             {

--- a/KachingPlugIn/Helpers/APIFacade.cs
+++ b/KachingPlugIn/Helpers/APIFacade.cs
@@ -11,7 +11,32 @@ namespace KachingPlugIn.Helpers
     {
         private static readonly ILogger _log = LogManager.GetLogger(typeof(APIFacade));
 
-        public static HttpStatusCode Delete(IList<string> ids, string url)
+        public static HttpStatusCode DeleteObject(object model, string url)
+        {
+            WebRequest request = WebRequest.Create(url);
+
+            request.Method = "DELETE";
+            request.ContentType = "application/json";
+
+            using (Stream dataStream = request.GetRequestStream())
+            using (StreamWriter streamWriter = new StreamWriter(dataStream))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new SnakeCaseNamingStrategy()
+                };
+                serializer.NullValueHandling = NullValueHandling.Ignore;
+
+                serializer.Serialize(streamWriter, model);
+            }
+
+            HttpWebResponse response = request.GetResponse() as HttpWebResponse;
+
+            return response.StatusCode;
+        }
+
+        public static HttpStatusCode Delete(IEnumerable<string> ids, string url)
         {
             var deleteUrl = url + "&ids=" + string.Join(",", ids);
             _log.Information("Delete url: " + deleteUrl);

--- a/KachingPlugIn/Helpers/StringExtensions.cs
+++ b/KachingPlugIn/Helpers/StringExtensions.cs
@@ -4,6 +4,9 @@ namespace KachingPlugIn.Helpers
 {
     public static class StringExtensions
     {
+        /// <summary>
+        /// Returns a key that is safe to import in Ka-ching, by lower-casing the key and replacing certain characters.
+        /// </summary>
         public static string KachingCompatibleKey(this string key)
         {
             return key.
@@ -16,6 +19,11 @@ namespace KachingPlugIn.Helpers
                 .Replace('[', '_')
                 .Replace(']', '_')
                 .Replace('#', '_');
+        }
+
+        public static bool IsValidProductRecommendationsImportUrl(this string url)
+        {
+            return IsValidUrl(url, "recommendations");
         }
 
         public static bool IsValidProductsImportUrl(this string url)
@@ -35,23 +43,30 @@ namespace KachingPlugIn.Helpers
 
         private static bool IsValidUrl(string url, string path)
         {
-            Uri uriResult;
-            if (Uri.TryCreate(url, UriKind.Absolute, out uriResult))
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uriResult))
             {
-                var https = uriResult.Scheme == Uri.UriSchemeHttps;
-                var validHost = IsValidHost(uriResult.Host);
-                var validPath = uriResult.LocalPath == "/imports/" + path;
-                return https && validHost && validPath;
+                return false;
             }
-            return false;
+
+            var https = uriResult.Scheme == Uri.UriSchemeHttps;
+            var validHost = IsValidHost(uriResult.Host);
+            var validPath = uriResult.LocalPath == "/imports/" + path;
+
+            return https && validHost && validPath;
         }
 
         private static bool IsValidHost(string host)
         {
-            return host == "us-central1-ka-ching-base-dev.cloudfunctions.net" ||
-                host == "us-central1-ka-ching-base-test.cloudfunctions.net" ||
-                host == "us-central1-ka-ching-base-staging.cloudfunctions.net" ||
-                host == "us-central1-ka-ching-base.cloudfunctions.net";
+            switch (host)
+            {
+                case "us-central1-ka-ching-base-dev.cloudfunctions.net":
+                case "us-central1-ka-ching-base-test.cloudfunctions.net":
+                case "us-central1-ka-ching-base-staging.cloudfunctions.net":
+                case "us-central1-ka-ching-base.cloudfunctions.net":
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/KachingPlugIn/Models/RecommendationGroup.cs
+++ b/KachingPlugIn/Models/RecommendationGroup.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace KachingPlugIn.KachingPlugIn.Models
+{
+    public class RecommendationGroup
+    {
+        [JsonProperty("product_id")]
+        public string ProductId { get; set; }
+
+        [JsonProperty("recommendations")]
+        public ICollection<string> Recommendations { get; set; }
+    }
+}

--- a/web.config.install.xdt
+++ b/web.config.install.xdt
@@ -11,6 +11,7 @@
   </episerver.shell>
 
   <kaching productsImportUrl=""
+           productRecommendationsImportUrl=""
            foldersImportUrl=""
            tagsImportUrl=""
            exportSingleVariantAsProduct="false" xdt:Transform="InsertIfMissing">


### PR DESCRIPTION
This pull request implements export of curated product recommendations, both on full product export and on association adds/updates/deletions.
All catalog entry associations on the Related Entries will be exported with the association group name as the key on the Ka-ching side.